### PR TITLE
Add interest level filters to each status column for job card management

### DIFF
--- a/.replit
+++ b/.replit
@@ -38,3 +38,6 @@ author = "agent"
 task = "shell.exec"
 args = "npm run dev"
 waitForPort = 5000
+
+[agent]
+expertMode = true

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { Prospect } from "@shared/schema";
-import { STATUSES } from "@shared/schema";
+import { STATUSES, INTEREST_LEVELS } from "@shared/schema";
 import { ProspectCard } from "@/components/prospect-card";
 import { AddProspectForm } from "@/components/add-prospect-form";
 import { Briefcase, Plus } from "lucide-react";
@@ -16,6 +16,8 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
 
+type InterestFilter = typeof INTEREST_LEVELS[number] | "All";
+
 const columnColors: Record<string, string> = {
   Bookmarked: "bg-blue-500",
   Applied: "bg-indigo-500",
@@ -26,6 +28,8 @@ const columnColors: Record<string, string> = {
   Withdrawn: "bg-gray-500",
 };
 
+const FILTER_OPTIONS: InterestFilter[] = ["All", ...INTEREST_LEVELS];
+
 function KanbanColumn({
   status,
   prospects,
@@ -35,6 +39,13 @@ function KanbanColumn({
   prospects: Prospect[];
   isLoading: boolean;
 }) {
+  const [interestFilter, setInterestFilter] = useState<InterestFilter>("All");
+
+  const filteredProspects =
+    interestFilter === "All"
+      ? prospects
+      : prospects.filter((p) => p.interestLevel === interestFilter);
+
   return (
     <div
       className="flex flex-col min-w-[260px] max-w-[320px] w-full bg-muted/40 rounded-md"
@@ -48,8 +59,22 @@ function KanbanColumn({
           className="ml-auto text-[10px] px-1.5 py-0 h-5 min-w-[20px] flex items-center justify-center no-default-active-elevate"
           data-testid={`badge-count-${status.replace(/\s+/g, "-").toLowerCase()}`}
         >
-          {prospects.length}
+          {filteredProspects.length}
         </Badge>
+      </div>
+      <div className="flex gap-1 px-2 pt-2">
+        {FILTER_OPTIONS.map((level) => (
+          <Button
+            key={level}
+            size="sm"
+            variant={interestFilter === level ? "default" : "ghost"}
+            onClick={() => setInterestFilter(level)}
+            className="h-6 px-2 text-[11px]"
+            data-testid={`filter-${level.toLowerCase()}-${status.replace(/\s+/g, "-").toLowerCase()}`}
+          >
+            {level}
+          </Button>
+        ))}
       </div>
       <div className="flex-1 overflow-y-auto px-2 py-2">
         <div className="space-y-2">
@@ -58,12 +83,14 @@ function KanbanColumn({
               <Skeleton className="h-28 rounded-md" />
               <Skeleton className="h-20 rounded-md" />
             </>
-          ) : prospects.length === 0 ? (
+          ) : filteredProspects.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-8 text-center" data-testid={`empty-${status.replace(/\s+/g, "-").toLowerCase()}`}>
-              <p className="text-xs text-muted-foreground">No prospects</p>
+              <p className="text-xs text-muted-foreground">
+                {prospects.length === 0 ? "No prospects" : "No matches"}
+              </p>
             </div>
           ) : (
-            prospects.map((prospect) => (
+            filteredProspects.map((prospect) => (
               <ProspectCard key={prospect.id} prospect={prospect} />
             ))
           )}


### PR DESCRIPTION
Introduces client-side filtering in `home.tsx` by adding state to `KanbanColumn` to manage `interestFilter` and conditionally render prospects based on `p.interestLevel` and `FILTER_OPTIONS`.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 802f5e1d-8e06-461c-9297-fa86aa150a5a
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: b277bc7b-2c86-4705-8636-71e262e7b644
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/8a8fac8c-9a55-4155-8662-febea68701e1/802f5e1d-8e06-461c-9297-fa86aa150a5a/T5FM2A9
Replit-Helium-Checkpoint-Created: true